### PR TITLE
Update deprecated versions of actions used

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -12,10 +12,10 @@ jobs:
     name: Artifact
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Artifact
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           operation: download
           location: artifact
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Initialize Terraform
         run: terraform init
@@ -37,7 +37,7 @@ jobs:
           terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
 
       - name: Upload Artifact
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           operation: upload
           location: artifact

--- a/.github/workflows/artifact_encrypted.yml
+++ b/.github/workflows/artifact_encrypted.yml
@@ -12,10 +12,10 @@ jobs:
     name: Artifact Encrypted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Encrypted Artifact & Decrypt Artifact
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           encryption_key: ${{ secrets.encryption_key }}
           operation: download
@@ -24,7 +24,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Initialize Terraform
         run: terraform init
@@ -38,7 +38,7 @@ jobs:
           terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
 
       - name: Encrypt Artifact & Upload Encrypted Artifact
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           encryption_key: ${{ secrets.encryption_key }}
           operation: upload

--- a/.github/workflows/repository_file.yml
+++ b/.github/workflows/repository_file.yml
@@ -12,12 +12,12 @@ jobs:
     name: Repository File
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.gh_access_token }}
 
       - name: Configure Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Initialize Terraform
         run: terraform init
@@ -36,7 +36,7 @@ jobs:
           ls -R
 
       - name: Commit Repository File
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           operation: upload
           location: repository

--- a/.github/workflows/repository_file_encrypted.yml
+++ b/.github/workflows/repository_file_encrypted.yml
@@ -12,12 +12,12 @@ jobs:
     name: Repository File Encrypted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.gh_access_token }}
 
       - name: Decrypt Repository File
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           encryption_key: ${{ secrets.encryption_key }}
           operation: download
@@ -25,7 +25,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Initialize Terraform
         run: terraform init
@@ -44,7 +44,7 @@ jobs:
           ls -R
 
       - name: Encrypt and Commit Repository File
-        uses: badgerhobbs/terraform-state@v1
+        uses: badgerhobbs/terraform-state@v2
         with:
           encryption_key: ${{ secrets.encryption_key }}
           operation: upload

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ It is recommended to use GitHub secrets to store the `encryption_key` and `githu
 
 ### Usage
 
-The following examples illustrates the best practices to use `terraform-state` to handle various scenarios of uploading and downloading a Terraform state file.
+The following examples illustrate the best practices to use `terraform-state` to handle various scenarios of uploading and downloading a Terraform state file.
 
 In addition, please note that while storing encrypted state within the repository ensures reasonable security, it is not recommended specifically for public repositories. Preferably, you should use artifacts. However, keep in mind that artifacts by default only last 90 days (can be changed in the repository settings).
 
-When using storing the Terraform state within the repository, changes are commited to the current branch. To prevent endless loops when the GitHub Action is triggered to run on push, configure the following.
+When storing the Terraform state within the repository, changes are commited to the current branch. To prevent endless loops when the GitHub Action is triggered to run on push, configure the following.
 
 ```yml
 push:
@@ -39,11 +39,11 @@ push:
 
 #### Artifact
 
-Please see thie [Example Workflow](.github/workflows/artifact.yml).
+Please see this [Example Workflow](.github/workflows/artifact.yml).
 
 ```yml
 - name: Download Artifact
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         operation: download
         location: artifact
@@ -51,7 +51,7 @@ Please see thie [Example Workflow](.github/workflows/artifact.yml).
     continue-on-error: true
 
 - name: Upload Artifact
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         operation: upload
         location: artifact
@@ -60,11 +60,11 @@ Please see thie [Example Workflow](.github/workflows/artifact.yml).
 
 #### Artifact Encrypted
 
-Please see thie [Example Workflow](.github/workflows/artifact_encrypted.yml).
+Please see this [Example Workflow](.github/workflows/artifact_encrypted.yml).
 
 ```yml
 - name: Download Encrypted Artifact & Decrypt Artifact
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         encryption_key: ${{ secrets.encryption_key }}
         operation: download
@@ -73,7 +73,7 @@ Please see thie [Example Workflow](.github/workflows/artifact_encrypted.yml).
     continue-on-error: true
 
 - name: Encrypt Artifact & Upload Encrypted Artifact
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         encryption_key: ${{ secrets.encryption_key }}
         operation: upload
@@ -83,11 +83,11 @@ Please see thie [Example Workflow](.github/workflows/artifact_encrypted.yml).
 
 #### Repository File
 
-Please see thie [Example Workflow](.github/workflows/repository_file.yml).
+Please see this [Example Workflow](.github/workflows/repository_file.yml).
 
 ```yml
 - name: Commit Repository File
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         operation: upload
         location: repository
@@ -95,11 +95,11 @@ Please see thie [Example Workflow](.github/workflows/repository_file.yml).
 
 #### Repository File Encrypted
 
-Please see thie [Example Workflow](.github/workflows/repository_file_encrypted.yml).
+Please see this [Example Workflow](.github/workflows/repository_file_encrypted.yml).
 
 ```yml
 - name: Decrypt Repository File
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         encryption_key: ${{ secrets.encryption_key }}
         operation: download
@@ -107,7 +107,7 @@ Please see thie [Example Workflow](.github/workflows/repository_file_encrypted.y
     continue-on-error: true
 
 - name: Encrypt and Commit Repository File
-    uses: badgerhobbs/terraform-state@v1
+    uses: badgerhobbs/terraform-state@v2
     with:
         encryption_key: ${{ secrets.encryption_key }}
         operation: upload

--- a/action.yml
+++ b/action.yml
@@ -52,10 +52,11 @@ runs:
 
     - name: Upload Artifact
       if: "${{ inputs.location == 'artifact' && inputs.operation == 'upload' && inputs.encryption_key == '' }}"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Terraform State
         path: "${{ inputs.directory }}/terraform.tfstate"
+        overwrite: true
 
     # Encrypted Artifact
     - name: Download Encrypted Artifact
@@ -88,10 +89,11 @@ runs:
 
     - name: Upload Encrypted Artifact
       if: "${{ inputs.location == 'artifact' && inputs.operation == 'upload' && inputs.encryption_key != '' }}"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Encrypted Terraform State
         path: "${{ inputs.directory }}/terraform.tfstate.encrypted"
+        overwrite: true
 
     # Repository File
     - name: Commit Repository File


### PR DESCRIPTION
Update versions of actions used to fix several warnings (Node.js, deprecated versions etc.):

- Update actions/upload-artifact to v4
- Update actions/checkout to v4
- Update badgerhobbs/terraform-state to v2
- Update hashicorp/setup-terraform to v3

CI tests will fail until the PR is accepted and a v2 release is prepared. Downstream CI tests pass OK: https://github.com/AlexGidarakos/terraform-state/actions